### PR TITLE
Add len() support for Outputs

### DIFF
--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -570,6 +570,10 @@ class Outputs:
 
         with open(filename, "w") as out_file:
             out_file.write(self.formatted(output_format))
+            
+    def __len__(self):
+        """Returns the number of entries in the history or bookmarks"""
+        return len(self.field_map[self.fetch_type]["var"])
 
 
 class ChromiumBasedBrowser(Browser, abc.ABC):


### PR DESCRIPTION
# Description


Add len() support for Outputs to Return the number of entries in the history or bookmarks

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
