### PR TITLE
Remove failing Python version check from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,16 +16,5 @@ except ImportError:
         "is missing. Please create a new virtual environment before proceeding"
     )
 
-import platform
-
-MIN_PYTHON_VERSION = ("3", "6")
-
-if platform.python_version_tuple() < MIN_PYTHON_VERSION:
-    raise SystemExit(
-        "Could not install browser-history in the environment. The"
-        " browser-history package requires python version 3.6+, you are using "
-        f"{platform.python_version()}"
-    )
-
 if __name__ == "__main__":
     setuptools.setup()


### PR DESCRIPTION
# Description
Version check in setup.py was failing for version of python newer than 3.10 due to the manner in which the comparison was being done. This was redundant with the check that pip already performs, and the minimum version is already specified in setup.cfg.

Fixes #245

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [ ] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [ ] Any dependent and pending changes have been merged and published
