### PR TITLE
fix: detect firefox installation via snap (linux)

### DIFF
--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -73,7 +73,7 @@ class Firefox(Browser):
         snap_install = (
             "snap/bin/" in subprocess.check_output("which firefox".split()).decode()
         )
-    except FileNotFoundError:
+    except (FileNotFoundError, subprocess.CalledProcessError):
         snap_install = False
     linux_path = (
         "snap/firefox/common/.mozilla/firefox" if snap_install else ".mozilla/firefox"

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -4,6 +4,7 @@ All browsers must inherit from :py:mod:`browser_history.generic.Browser`.
 """
 import datetime
 import sqlite3
+import subprocess
 
 from browser_history.generic import Browser, ChromiumBasedBrowser
 
@@ -65,7 +66,18 @@ class Firefox(Browser):
     name = "Firefox"
     aliases = ("firefoxurl",)
 
-    linux_path = ".mozilla/firefox"
+    # Determine if Firefox was installed by snap or by normal method
+    try:
+        # find firefox executable. This may fail if not in linux or if Firefox is not
+        # installed, in which case we default to False
+        snap_install = (
+            "snap/bin/" in subprocess.check_output("which firefox".split()).decode()
+        )
+    except FileNotFoundError:
+        snap_install = False
+    linux_path = (
+        "snap/firefox/common/.mozilla/firefox" if snap_install else ".mozilla/firefox"
+    )
     windows_path = "AppData/Roaming/Mozilla/Firefox/Profiles"
     mac_path = "Library/Application Support/Firefox/Profiles/"
 
@@ -144,6 +156,7 @@ class LibreWolf(Firefox):
 
     Profile support: Yes
     """
+
     name = "LibreWolf"
     aliases = ("librewolfurl",)
 

--- a/tests/test_browsers.py
+++ b/tests/test_browsers.py
@@ -15,8 +15,12 @@ from .utils import (  # noqa: F401; pylint: disable=unused-import
 # pylint: disable=redefined-outer-name,unused-argument
 
 
-def test_firefox_linux(become_linux, change_homedir):  # noqa: F811
+def test_firefox_linux(become_linux, change_homedir, monkeypatch):  # noqa: F811
     """Test history is correct on Firefox for Linux"""
+    # Make sure we run this test with firefox in the default (non-snap) directory
+    monkeypatch.setattr(
+        "browser_history.browsers.Firefox.linux_path", ".mozilla/firefox"
+    )
     f = browser_history.browsers.Firefox()
     h_output = f.fetch_history()
     b_output = f.fetch_bookmarks()
@@ -587,6 +591,7 @@ def test_vivaldi_mac(become_mac, change_homedir):  # noqa: F811
         ),
     )
 
+
 def test_librewolf_linux(become_linux, change_homedir):  # noqa: F811
     """Test history is correct on LibreWolf for Linux"""
     f = browser_history.browsers.LibreWolf()
@@ -596,7 +601,7 @@ def test_librewolf_linux(become_linux, change_homedir):  # noqa: F811
     bmk = b_output.bookmarks
     assert len(his) == 12
     assert len(bmk) == 1
-    
+
     assert_histories_equal(
         his[0],
         (


### PR DESCRIPTION
# Description

Check firefox installation path in linux. If the path includes
`snap/bin/` then it's been installed with the snap package manager, and the path to the Firefox's profiles will be different.

Fixes #262 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [ ] Any dependent and pending changes have been merged and published
