### PR TITLE
[FIX] make Outputs work even when .histories is overwritten

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -16,7 +16,7 @@ from browser_history import (
 # get list of all implemented browser by finding subclasses of generic.Browser
 AVAILABLE_BROWSERS = ", ".join(b.__name__ for b in utils.get_browsers())
 AVAILABLE_FORMATS = ", ".join(generic.Outputs(fetch_type=None).format_map.keys())
-AVAILABLE_TYPES = ", ".join(generic.Outputs(fetch_type=None).field_map.keys())
+AVAILABLE_TYPES = ", ".join(generic.Outputs._valid_fetch_types)
 
 
 def make_parser():

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -12,6 +12,7 @@ import shutil
 import sqlite3
 import tempfile
 import typing
+import warnings
 from collections import defaultdict
 from functools import partial
 from io import StringIO
@@ -382,7 +383,28 @@ class Outputs:
             "jsonl": partial(self.to_json, json_lines=True),
         }
 
+    @property
+    def field_map(self) -> typing.Dict[str, typing.Any]:
+        """[Deprecated] This was not meant for public usage and will be removed soon.
+
+        Use _get_data and _get_fields if you really need this.
+        """
+        warnings.warn(
+            "Outputs.field_map is deprecated. This property was not "
+            + "meant for public usage. Use _get_data and _get_fields "
+            + "if you really need this.",
+            DeprecationWarning,
+        )
+        return {
+            "history": {"var": self.histories, "fields": ("Timestamp", "URL")},
+            "bookmarks": {
+                "var": self.bookmarks,
+                "fields": ("Timestamp", "URL", "Title", "Folder"),
+            },
+        }
+
     def _get_data(self):
+        """Return the list of histories or bookmarks (depending on `fetch_type`)."""
         if self.fetch_type == "history":
             return self.histories
         elif self.fetch_type == "bookmarks":
@@ -391,6 +413,7 @@ class Outputs:
             raise ValueError(f"Invalid fetch type {self.fetch_type}")
 
     def _get_fields(self):
+        """Return names of the fields of the data."""
         if self.fetch_type == "history":
             return ("Timestamp", "URL", "Title")
         elif self.fetch_type == "bookmarks":

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -17,7 +17,6 @@ def test_outputs_init():
     obj = generic.Outputs("history")
     assert not obj.histories
     assert obj.format_map
-    assert obj.field_map
 
 
 @pytest.mark.parametrize(
@@ -75,6 +74,10 @@ def test_output_sort_domain(entries, exp_res):
     """test Outputs.sort_domain"""
     obj = generic.Outputs("history")
     obj.histories.extend(entries)
+    assert list(obj.sort_domain().items()) == exp_res
+
+    obj = generic.Outputs("history")
+    obj.histories = entries
     assert list(obj.sort_domain().items()) == exp_res
 
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -81,6 +81,22 @@ def test_output_sort_domain(entries, exp_res):
     assert list(obj.sort_domain().items()) == exp_res
 
 
+def test_output_invalid_fetch_type():
+    obj = generic.Outputs("history")
+    assert obj._get_data() == []
+    assert obj._get_fields() is not None
+
+    obj = generic.Outputs("bookmarks")
+    assert obj._get_data() == []
+    assert obj._get_fields() is not None
+
+    obj = generic.Outputs("bistory")
+    with pytest.raises(ValueError):
+        obj._get_data()
+    with pytest.raises(ValueError):
+        obj._get_fields()
+
+
 class _CustomBrowser(generic.Browser):
     name = "Custom browser"
     history_file = ""

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -81,7 +81,8 @@ def test_output_sort_domain(entries, exp_res):
     assert list(obj.sort_domain().items()) == exp_res
 
 
-def test_output_invalid_fetch_type():
+def test_outputs_invalid_fetch_type():
+    """Check that there's an error raised when an invalid fetch_type is used."""
     obj = generic.Outputs("history")
     assert obj._get_data() == []
     assert obj._get_fields() is not None
@@ -95,6 +96,15 @@ def test_output_invalid_fetch_type():
         obj._get_data()
     with pytest.raises(ValueError):
         obj._get_fields()
+
+
+def test_outputs_field_map():
+    """Check that the field_map property exists on Outputs."""
+
+    obj = generic.Outputs("history")
+
+    with pytest.deprecated_call():
+        assert isinstance(obj.field_map, dict)
 
 
 class _CustomBrowser(generic.Browser):


### PR DESCRIPTION
# Description

When `Outputs.histories` (or `Outputs.bookmarks`) is being overwritten, the methods did not work correctly since they still pointed to the old variable. An example of this can be seen in [the docs for `sort_domain`](https://browser-history.readthedocs.io/en/stable/outputs.html#browser_history.generic.Outputs.sort_domain).

The PR fixes it and adds a test for it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [ ] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
