### PR TITLE
Fix Safari issue with no titles for history item

### DIFF
--- a/browser_history/__init__.py
+++ b/browser_history/__init__.py
@@ -1,6 +1,5 @@
 from . import browsers, generic, utils  # noqa: F401
 
-
 __version__ = "0.4.0"
 
 
@@ -23,7 +22,9 @@ def get_history():
             output_object.histories.extend(browser_output_object.histories)
         except AssertionError:
             utils.logger.info("%s browser is not supported", browser_class.name)
-    output_object.histories.sort()
+    # Can't sort tuples with None values, and some titles
+    # are None, so replace them with ''
+    output_object.histories.sort(key=lambda h: tuple(el or "" for el in h))
     return output_object
 
 

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -2,6 +2,7 @@
 
 All browsers must inherit from :py:mod:`browser_history.generic.Browser`.
 """
+
 import datetime
 import sqlite3
 
@@ -145,6 +146,7 @@ class LibreWolf(Firefox):
 
     Profile support: Yes
     """
+
     name = "LibreWolf"
     aliases = ("librewolfurl",)
 
@@ -287,6 +289,7 @@ class Vivaldi(ChromiumBasedBrowser):
     windows_path = "AppData/Local/Vivaldi/User Data"
 
     profile_support = True
+
 
 class Epic(ChromiumBasedBrowser):
     """Epic Privacy Browser

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -2,6 +2,7 @@
 Module defines Platform class enumerates the popular Operating Systems.
 
 """
+
 import enum
 import inspect
 import logging

--- a/tests/test_browsers.py
+++ b/tests/test_browsers.py
@@ -36,7 +36,7 @@ def test_firefox_linux(become_linux, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
             "https://www.mozilla.org/en-US/privacy/firefox/",
-            "Firefox Privacy Notice — Mozilla"
+            "Firefox Privacy Notice — Mozilla",
         ),
     )
     assert_bookmarks_equal(
@@ -78,7 +78,7 @@ def test_firefox_linux(become_linux, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
             "https://www.mozilla.org/en-US/privacy/firefox/",
-            "Firefox Privacy Notice — Mozilla"
+            "Firefox Privacy Notice — Mozilla",
         ),
     )
 
@@ -112,7 +112,7 @@ def test_chrome_linux(become_linux, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
             ),
             "www.github.com",
-            "GitHub: Where the world builds software · GitHub"
+            "GitHub: Where the world builds software · GitHub",
         ),
     )
     assert_bookmarks_equal(
@@ -153,7 +153,7 @@ def test_chrome_linux(become_linux, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
             ),
             "www.github.com",
-            "GitHub: Where the world builds software · GitHub"
+            "GitHub: Where the world builds software · GitHub",
         ),
     )
 
@@ -180,7 +180,7 @@ def test_chromium_linux(become_linux, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
             ),
             "www.github.com",
-            "GitHub: Where the world builds software · GitHub"
+            "GitHub: Where the world builds software · GitHub",
         ),
     )
     assert_bookmarks_equal(
@@ -227,7 +227,7 @@ def test_chromium_linux(become_linux, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
             ),
             "www.github.com",
-            "GitHub: Where the world builds software · GitHub"
+            "GitHub: Where the world builds software · GitHub",
         ),
     )
 
@@ -259,7 +259,7 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://www.youtube.com/",
-            "YouTube"
+            "YouTube",
         ),
     )
     assert_bookmarks_equal(
@@ -294,7 +294,7 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://www.reddit.com/",
-            "reddit: the front page of the internet"
+            "reddit: the front page of the internet",
         ),
     )
     # get history for second profile
@@ -315,7 +315,7 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://www.reddit.com/",
-            "reddit: the front page of the internet"
+            "reddit: the front page of the internet",
         ),
     )
 
@@ -342,7 +342,7 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://pesos.github.io/",
-            "Welcome to PES Open Source - PES Open Source"
+            "Welcome to PES Open Source - PES Open Source",
         ),
     )
 
@@ -371,7 +371,7 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://pesos.github.io/",
-            "Welcome to PES Open Source - PES Open Source"
+            "Welcome to PES Open Source - PES Open Source",
         ),
     )
 
@@ -396,7 +396,7 @@ def test_safari_mac(become_mac, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
             "https://www.apple.com/in/",
-            ""
+            "",
         ),
     )
     assert his[1][1] == "https://www.google.co.in/?client=safari&channel=mac_bm"
@@ -413,7 +413,7 @@ def test_safari_mac(become_mac, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
             "https://pesos.github.io/",
-            None
+            None,
         ),
     )
 
@@ -441,7 +441,7 @@ def test_opera_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://www.youtube.com/",
-            "YouTube"
+            "YouTube",
         ),
     )
     assert_bookmarks_equal(
@@ -477,7 +477,7 @@ def test_opera_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://github.com/",
-            "GitHub: Where the world builds software · GitHub"
+            "GitHub: Where the world builds software · GitHub",
         ),
     )
     assert len(o.profiles(o.history_file)) == 1
@@ -510,7 +510,7 @@ def test_brave_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://github.com/",
-            "GitHub: Where the world builds software · GitHub"
+            "GitHub: Where the world builds software · GitHub",
         ),
     )
     assert_bookmarks_equal(
@@ -545,7 +545,7 @@ def test_brave_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://stackoverflow.com/",
-            "Stack Overflow - Where Developers Learn, Share, & Build Careers"
+            "Stack Overflow - Where Developers Learn, Share, & Build Careers",
         ),
     )
     # get history for second profile
@@ -565,7 +565,7 @@ def test_brave_windows(become_windows, change_homedir):  # noqa: F811
                 ),
             ),
             "https://www.reddit.com/",
-            "reddit: the front page of the internet"
+            "reddit: the front page of the internet",
         ),
     )
 
@@ -592,7 +592,7 @@ def test_vivaldi_mac(become_mac, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
             "https://vivaldi.com/whats-new-in-vivaldi-3-5/",
-            "What’s New in Vivaldi 3.5 | Vivaldi Browser"
+            "What’s New in Vivaldi 3.5 | Vivaldi Browser",
         ),
     )
 
@@ -610,9 +610,10 @@ def test_vivaldi_mac(become_mac, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
             "https://pesos.github.io/",
-            "Welcome to PES Open Source - PES Open Source"
+            "Welcome to PES Open Source - PES Open Source",
         ),
     )
+
 
 def test_librewolf_linux(become_linux, change_homedir):  # noqa: F811
     """Test history is correct on LibreWolf for Linux"""
@@ -623,7 +624,7 @@ def test_librewolf_linux(become_linux, change_homedir):  # noqa: F811
     bmk = b_output.bookmarks
     assert len(his) == 12
     assert len(bmk) == 1
-    
+
     assert_histories_equal(
         his[0],
         (
@@ -637,7 +638,7 @@ def test_librewolf_linux(become_linux, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
             "https://duckduckgo.com/?t=ffab&q=fhgi",
-            "fhgi at DuckDuckGo"
+            "fhgi at DuckDuckGo",
         ),
     )
 
@@ -659,6 +660,7 @@ def test_librewolf_linux(become_linux, change_homedir):  # noqa: F811
         ),
     )
 
+
 def test_epic_windows(become_windows, change_homedir):  # noqa: F811
     """Test history is correct on Epic for Windows"""
     f = browser_history.browsers.Epic()
@@ -679,11 +681,11 @@ def test_epic_windows(become_windows, change_homedir):  # noqa: F811
                 26,
                 28,
                 tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), 'India Standard Time'
-                )
+                    datetime.timedelta(seconds=19800), "India Standard Time"
+                ),
             ),
-            'https://github.com/',
-            'GitHub: Let’s build from here · GitHub'
+            "https://github.com/",
+            "GitHub: Let’s build from here · GitHub",
         ),
     )
     assert_bookmarks_equal(
@@ -697,13 +699,13 @@ def test_epic_windows(become_windows, change_homedir):  # noqa: F811
                 34,
                 7,
                 tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), 'India Standard Time'
+                    datetime.timedelta(seconds=19800), "India Standard Time"
                 ),
             ),
-            'https://github.com/',
-            'GitHub: Let’s build from here · GitHub',
-            'bookmark_bar'
-        )
+            "https://github.com/",
+            "GitHub: Let’s build from here · GitHub",
+            "bookmark_bar",
+        ),
     )
 
 
@@ -726,12 +728,10 @@ def test_epic_mac(become_mac, change_homedir):  # noqa: F811
                 20,
                 19,
                 49,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), 'IST'
-                )
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
-            'https://epicbrowser.com/encrypted_proxy/',
-            "Epic Privacy Browser - Epic's Encrypted Proxy (VPN)"
+            "https://epicbrowser.com/encrypted_proxy/",
+            "Epic Privacy Browser - Epic's Encrypted Proxy (VPN)",
         ),
     )
     assert_bookmarks_equal(
@@ -744,12 +744,10 @@ def test_epic_mac(become_mac, change_homedir):  # noqa: F811
                 20,
                 22,
                 1,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), 'IST'
-                )
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
             ),
-            'https://github.com/',
-            'GitHub: Let’s build from here · GitHub',
-            'bookmark_bar'
-        )
+            "https://github.com/",
+            "GitHub: Let’s build from here · GitHub",
+            "bookmark_bar",
+        ),
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,7 +150,7 @@ def test_browser_argument(browser_arg, capsys, platform):
                 for browser_unavailable_err in (
                     "browser is not supported",
                     "browser is not installed",
-                    "browser is unavailable"
+                    "browser is unavailable",
                 )
             ):
                 # In case the tester does not have access to the browser
@@ -178,7 +178,7 @@ def test_format_argument(capsys, platform):
     # and we don't mind the CSV dialect, so just check call doesn't error
     read_csv = csv.Sniffer()
     # This gives '_csv.Error: Could not determine delimiter' if not a csv file
-    csv_output = csv_output.replace('\r', '')
+    csv_output = csv_output.replace("\r", "")
     read_csv.sniff(csv_output)
     assert read_csv.has_header(
         csv_output
@@ -189,7 +189,7 @@ def test_format_argument(capsys, platform):
             cli([fmt_opt, fmt_arg])
             output = capsys.readouterr().out
             if fmt_arg in ("csv", "infer"):  # infer gives csv if no file
-                output = output.replace('\r', '')
+                output = output.replace("\r", "")
                 read_csv.sniff(output)
                 assert read_csv.has_header(output)
                 assert CSV_HISTORY_HEADER in output
@@ -245,7 +245,7 @@ def test_argument_combinations(capsys, platform, browser):
                         "browser is not supported",
                         "browser is not installed",
                         "Bookmarks are not supported",
-                        "browser is unavailable"
+                        "browser is unavailable",
                     )
                 ):
                     # In case the tester does not have access to the browser
@@ -482,7 +482,9 @@ def test_firefox_windows_profile(capsys, become_windows, change_homedir):  # noq
 
     out, err = capsys.readouterr()
     assert out.startswith("Timestamp,URL,Title")
-    assert out.endswith("https://www.reddit.com/,reddit: the front page of the internet\r\n\n")
+    assert out.endswith(
+        "https://www.reddit.com/,reddit: the front page of the internet\r\n\n"
+    )
     assert err == ""
 
 

--- a/tests/test_none_values.py
+++ b/tests/test_none_values.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from pytest import MonkeyPatch
+
+from browser_history.browsers import Safari
+from browser_history.generic import Outputs
+
+from .utils import (  # noqa: F401; pylint: disable=unused-import
+    become_mac,
+    change_homedir,
+)
+
+# pylint: disable=redefined-outer-name,unused-argument
+
+
+def test_none_titles(become_mac, change_homedir, monkeypatch: MonkeyPatch):
+    # see https://github.com/browser-history/browser-history/issues/272
+    # and https://github.com/browser-history/browser-history/pull/273
+
+    outputs = Outputs("history")
+    same_time = datetime.now().astimezone()
+    outputs.histories = [(same_time, "same_url", "Title"), (same_time, "same_url", None)]
+
+    monkeypatch.setattr(Safari, "fetch_history", lambda *args: outputs)
+
+    from browser_history import get_history
+
+    outputs = get_history()


### PR DESCRIPTION
# Description

Some Safari entries have no title. If this is the case, and they have
the same URL and datetime, then we can't sort them. Python doesn't allow
comparing strings and None.

This uses the solution here:
<https://stackoverflow.com/questions/60695318/sort-a-list-of-tuples-with-none-values-in-python3>

It does not affect the output. If the datetime were to ever be None,
this could cause an issue, potentially.

The diff is large because of running black/fixing flake8 issues so the pre-commit hooks pass.

Fixes: https://github.com/browser-history/browser-history/issues/272

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
