### PR TITLE
[CI] Update codecov uploader to v4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         pytest --cov=./browser_history --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml


### PR DESCRIPTION
# Description

Tests are failing due to not being able to upload to codecov. Trying to see if this fixes it.