### PR TITLE
[CI] Update readthedocs config to the new format

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,18 +1,19 @@
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF
 formats:
   - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Not even sure if this is a new format, but the docs build was failing on readthedocs:
```
Config validation error in build.os. Value build not found.
```