### PR TITLE
[MISC] Drop support for Python 3.7

### DIFF
--- a/.github/workflows/python-mypy.yml
+++ b/.github/workflows/python-mypy.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         platform: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ package to retrieve (almost) any browser's history on (almost) any platform.
  - A **command-line tool**: simply run `browser-history --help` from your terminal.
  - **History**: browsing history with exact timestamp and URL.
  - **Bookmarks**: browser bookmarks with timestamp, URL, title and folder.
- - Lightweight: the entire package is less than 20kB in size and has no dependencies other than python 3.7+.
+ - Lightweight: the entire package is less than 20kB in size and has no dependencies other than python 3.8+.
  - Developer friendly: you can add support for new browsers or add a new feature very easily.
  - Default browser: can automatically determine the default browser on Windows and Linux (`browser-history -b default`).
  - Fully open source: this project is developed and maintained by the [`browser-history` organization](https://github.com/browser-history) (previously maintained by [PESOS](https://github.com/pesos)) and will always be open source (with the Apache 2.0 License).

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -4,7 +4,7 @@ Contributing
 Development Dependencies
 ------------------------
 
-#. Python 3 (versions 3.6 to 3.8 are currently supported)
+#. Python 3 (versions 3.8 to 3.12 are currently supported)
 #. ``pip install pylint pytest pytest-cov pre-commit python-dateutil``
 
     * ``pylint`` to check for errors and to enforce code style.


### PR DESCRIPTION
Python 3.7 went end-of-life 10 months ago: https://devguide.python.org/versions/#unsupported-versions

While this commmit does not forbid browser-history being installed with python 3.7 (which would be done in setup.cfg), it will be removed along with the update to using pyproject.toml in a separate PR.

See https://github.com/browser-history/browser-history/pull/279 for the WIP pyproject.toml PR and for some more reasons to drop 3.7.