### PR TITLE
[CLI] Handle BrokenPipeError and KeyboardInterrupt (#281)

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -215,4 +215,11 @@ def cli(args):
 
 
 def main():
-    cli(sys.argv[1:])
+    try:
+        cli(sys.argv[1:])
+    except BrokenPipeError:
+        # ignore broken pipe errors just in case output is
+        # piped to another command
+        pass
+    except KeyboardInterrupt:
+        sys.exit(1)


### PR DESCRIPTION
# Description
Piping output from the CLI in the terminal sometimes results in a `BrokenPipeError` which is currently unhandled. This PR adds handling of `BrokenPipeError` as well as `KeyboardInterrupt` which are the most common types of errors likely to occur during normal usage of the CLI.

Fixes #281

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
