### PR TITLE
[FIX] sorting bookmarks with some `None` values

### DIFF
--- a/browser_history/__init__.py
+++ b/browser_history/__init__.py
@@ -50,5 +50,5 @@ def get_bookmarks():
             output_object.bookmarks.extend(browser_output_object.bookmarks)
         except AssertionError as e:
             utils.logger.info("%s", e)
-    output_object.bookmarks.sort()
+    output_object.bookmarks.sort(key=utils.bookmarks_sort_key)
     return output_object

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -341,7 +341,7 @@ class Browser(abc.ABC):
                 date_bookmarks = self.bookmarks_parser(copied_bookmark_path)
                 output_object.bookmarks.extend(date_bookmarks)
             if sort:
-                output_object.bookmarks.sort(reverse=desc)
+                output_object.bookmarks.sort(reverse=desc, key=utils.bookmarks_sort_key)
         return output_object
 
     @classmethod

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -3,12 +3,13 @@ Module defines Platform class enumerates the popular Operating Systems.
 
 """
 
+import datetime
 import enum
 import inspect
 import logging
 import platform
 import subprocess
-from typing import Optional
+from typing import Optional, Tuple
 
 from . import generic
 
@@ -214,3 +215,12 @@ def get_browser(browser_name):
             )
 
         return browser_class
+
+
+def bookmarks_sort_key(
+    bookmark: Tuple[datetime.datetime, str, str, str]
+) -> Tuple[datetime.datetime, Tuple[bool, str], Tuple[bool, str], Tuple[bool, str]]:
+    time, url, title, folder = bookmark
+    # (x is None, x) pattern is used to sort `None`s last.
+    #  - Since `False < True`, `None` values will be moved to the end.
+    return time, (url is None, url), (title is None, title), (folder is None, folder)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -199,3 +199,42 @@ def test_chromium_based_browser_bookmark_parser_deep_hierarchy():
         with patch("browser_history.generic.json.load", Mock(return_value=nodes)):
             bookmark_list = browser.bookmarks_parser("/")
     assert len(bookmark_list) == 1
+
+
+def test_bookmarks_with_none_values_sorted():
+    class CustomChromiumBrowser(ChromiumBasedBrowser):
+        name = "Test"
+        linux_path = "random_path"
+
+        def paths(self, profile_file):
+            # can be anything. just needs to be a valid path.
+            return [pathlib.Path("README.md")]
+
+    browser = CustomChromiumBrowser(utils.Platform.LINUX)
+    nodes = {
+        "roots": {
+            "key": {
+                "parent": {
+                    "children": [
+                        {
+                            "type": "url",
+                            "date_added": int(datetime.now().timestamp()),
+                            "url": "foo.bar",
+                            "name": "foo",
+                        },
+                        {
+                            "type": "url",
+                            "date_added": int(datetime.now().timestamp()),
+                            "url": None,
+                            "name": "foo",
+                        },
+                    ]
+                }
+            }
+        }
+    }
+    with patch("browser_history.generic.open"):
+        with patch("browser_history.generic.json.load", Mock(return_value=nodes)):
+            bookmark_list = browser.fetch_bookmarks(sort=True)
+    assert len(bookmark_list.bookmarks) == 2
+    assert bookmark_list.bookmarks[1][1] is None


### PR DESCRIPTION
# Description

Add a `bookmarks_sort_key` util that is used to sort bookmarks.

Fixes #286

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
